### PR TITLE
Fix: Experiment API

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/transformers/ExperimentTransformer.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/transformers/ExperimentTransformer.java
@@ -49,6 +49,7 @@ public class ExperimentTransformer extends AbstractTransformer {
                 .set(record.getBonusAnswer(), Experiment.Builder::setPaymentAnswer)
                 .set(record.getBonusRating(), Experiment.Builder::setPaymentRating)
                 .set(record.getTemplateData(), ((builder, s) -> builder.putAllPlaceholders(new Gson().fromJson(s, type))))
+                .set(record.getTemplate(), Experiment.Builder::setTemplateId)
                 .set(record.getWorkerQualityThreshold(), Experiment.Builder::setWorkerQualityThreshold)
                 .getBuilder()
                 .build();

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/transformers/ExperimentTransformer.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/transformers/ExperimentTransformer.java
@@ -134,9 +134,6 @@ public class ExperimentTransformer extends AbstractTransformer {
                 case Experiment.DESCRIPTION_FIELD_NUMBER:
                     record.setDescription(experiment.getDescription());
                     break;
-                case Experiment.ID_FIELD_NUMBER:
-                    record.setIdExperiment(experiment.getId());
-                    break;
                 case Experiment.PAYMENT_ANSWER_FIELD_NUMBER:
                     record.setBonusAnswer(experiment.getPaymentAnswer());
                     break;

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/rest/resources/ExperimentResource.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/rest/resources/ExperimentResource.java
@@ -65,6 +65,7 @@ public class ExperimentResource {
         int from = getQueryInt(request, "from", 0);
         boolean asc = getQueryBool(request, "asc", true);
 
+        // TODO: (low priority) Optimize fetchExperiment for multiple experiments
         return experimentOperations.getExperimentsFrom(from, asc, 20)
                 .map(experimentRecord -> fetchExperiment(experimentRecord.getIdExperiment()))
                 .constructPaginated(ExperimentList.newBuilder(),ExperimentList.Builder::addAllItems);

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/rest/resources/ExperimentResource.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/rest/resources/ExperimentResource.java
@@ -66,10 +66,7 @@ public class ExperimentResource {
         boolean asc = getQueryBool(request, "asc", true);
 
         return experimentOperations.getExperimentsFrom(from, asc, 20)
-                .map(experimentRecord -> ExperimentTransformer.toProto(
-                        experimentRecord,
-                        experimentOperations.getExperimentState(experimentRecord.getIdExperiment()))
-                )
+                .map(experimentRecord -> fetchExperiment(experimentRecord.getIdExperiment()))
                 .constructPaginated(ExperimentList.newBuilder(),ExperimentList.Builder::addAllItems);
     }
 


### PR DESCRIPTION
- Return `templateId` correctly
- Return full experiments in experiment lists
