### PR TITLE
Crowdplatform db fix

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
@@ -54,20 +54,27 @@ public class PlatformManager {
         //create hashmap of platforms
         platforms = crowdPlatforms.stream()
                 .collect(Collectors.toMap(Platform::getID, Function.identity()));
-        //clear database
-        platformOps.deleteAllPlatforms();
+
         //update database
         platforms.forEach((s, platform) -> {
-            PlatformRecord rec = new PlatformRecord();
-            rec.setIdPlatform(platform.getID());
-            rec.setName(platform.getName());
-            rec.setNeedsEmail(false);
+            Optional<edu.kit.ipd.crowdcontrol.objectservice.proto.Platform> databasestate
+                    = platformOps.getPlatform(platform.getID());
 
-            rec.setNeedsEmail(isNeedemail(platform));
-            rec.setRenderCalibrations(platform.isCalibrationAllowed());
+            if (!databasestate.isPresent()) {
+                PlatformRecord rec = new PlatformRecord();
+                rec.setIdPlatform(platform.getID());
+                rec.setName(platform.getName());
+                rec.setNeedsEmail(false);
 
-            platformOps.createPlatform(rec);
+                rec.setNeedsEmail(isNeedemail(platform));
+                rec.setRenderCalibrations(platform.isCalibrationAllowed());
+
+                platformOps.createPlatform(rec);
+            }
         });
+
+        //FIXME we should check if there are
+        // platforms which are not active anymore, if they are we should lock them
     }
 
     private boolean isNeedemail(Platform platform) {

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
@@ -9,6 +9,7 @@ import edu.kit.ipd.crowdcontrol.objectservice.database.operations.PlatformOperat
 import edu.kit.ipd.crowdcontrol.objectservice.database.operations.TasksOperations;
 import edu.kit.ipd.crowdcontrol.objectservice.database.operations.WorkerOperations;
 import edu.kit.ipd.crowdcontrol.objectservice.proto.Experiment;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,7 @@ public class PlatformManager {
             //we cannot find this platform in our instance mark it dead
             if (platform == null) {
                 //TODO record.setLockBit(true);
+                LogManager.getLogger("Crowdplatform").fatal("Mark platform "+record.getIdPlatform()+" as locked");
                 platformOps.updatePlatform(record);
             }
         }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/PlatformOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/PlatformOperations.java
@@ -63,11 +63,4 @@ public class PlatformOperations extends AbstractOperations {
         assertHasPrimaryKey(platformRecord);
         return create.executeInsert(platformRecord) == 1;
     }
-
-    /**
-     * Delete all platforms existing in the database.
-     */
-    public void deleteAllPlatforms() {
-        create.deleteFrom(Tables.PLATFORM).execute();
-    }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/PlatformOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/PlatformOperations.java
@@ -66,10 +66,18 @@ public class PlatformOperations extends AbstractOperations {
         return create.executeInsert(platformRecord) == 1;
     }
 
+    /**
+     * Update the record of the given id with the new values
+     * @param rec A new Platformrecord
+     */
     public void updatePlatform(PlatformRecord rec) {
         //TODO LEAAAAANDER
     }
 
+    /**
+     * Get a List of all Platforms
+     * @return List containing all platforms which are currently in the database
+     */
     public List<PlatformRecord> getPlatforms() {
         //TODO LEAAAAANDER
         return Collections.emptyList();

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/PlatformOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/PlatformOperations.java
@@ -8,6 +8,8 @@ import edu.kit.ipd.crowdcontrol.objectservice.proto.Platform;
 import org.jooq.DSLContext;
 import org.jooq.SelectConditionStep;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static edu.kit.ipd.crowdcontrol.objectservice.database.model.Tables.PLATFORM;
@@ -62,5 +64,14 @@ public class PlatformOperations extends AbstractOperations {
     public boolean createPlatform(PlatformRecord platformRecord) throws IllegalArgumentException {
         assertHasPrimaryKey(platformRecord);
         return create.executeInsert(platformRecord) == 1;
+    }
+
+    public void updatePlatform(PlatformRecord rec) {
+        //TODO LEAAAAANDER
+    }
+
+    public List<PlatformRecord> getPlatforms() {
+        //TODO LEAAAAANDER
+        return Collections.emptyList();
     }
 }

--- a/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManagerTest.java
+++ b/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManagerTest.java
@@ -11,10 +11,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.Mockito.*;
@@ -44,6 +41,11 @@ public class PlatformManagerTest {
         tasksOps = mock(TasksOperations.class);
         platformOps = mock(PlatformOperations.class);
         workerOps = mock(WorkerOperations.class);
+
+        when(platformOps.getPlatforms()).thenReturn(Collections.emptyList());
+        when(platformOps.getPlatform("test1")).thenReturn(Optional.empty());
+        when(platformOps.getPlatform("test2")).thenReturn(Optional.empty());
+        when(platformOps.getPlatform("test3")).thenReturn(Optional.empty());
 
         manager = new PlatformManager(platforms,
                 param -> "42",

--- a/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManagerTest.java
+++ b/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManagerTest.java
@@ -54,7 +54,6 @@ public class PlatformManagerTest {
     }
     @Test
     public void dbinit(){
-        verify(platformOps).deleteAllPlatforms();
 
         platforms.forEach(platform -> {
             //check that every platform got init


### PR DESCRIPTION
We have to keep the database consistent, for the case a platform disappears in our installation we need to mark this platform somehow as dead. So we can keep our database halfway consistent.
