### PR TITLE
rest: fixed bug causing answertype to be set

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/transformers/ExperimentTransformer.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/transformers/ExperimentTransformer.java
@@ -99,7 +99,7 @@ public class ExperimentTransformer extends AbstractTransformer {
     }
 
     private static String transform(AnswerType answerType) {
-        if (answerType == AnswerType.INVALID) return null;
+        if (answerType == AnswerType.INVALID || answerType == AnswerType.TEXT) return null;
         return answerType.name();
     }
 


### PR DESCRIPTION
if the proto-answertype is TEXT, answertype in the db must be null
(cherry picked from commit 77b4c20)
