### PR TITLE
Fix workerIdentfication to not call identifyWorker() more than once

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
@@ -233,12 +233,12 @@ public class PlatformManager {
     /**
      * Get a worker if he exists
      * @param name Name of the platform
-     * @param params Params passed by the platform
+     * @param identification The previously obtained identification of the worker
      * @return A worker if one is found
      * @throws UnidentifiedWorkerException if the platform does not identify a worker
      */
-    public Optional<WorkerRecord> getWorker(String name, Map<String ,String[]> params) throws UnidentifiedWorkerException {
-        return getWorker(name).getWorker(workerOps,name,params);
+    public Optional<WorkerRecord> getWorker(String name, String identification) throws UnidentifiedWorkerException {
+        return getWorker(name).getWorker(identification, workerOps, name);
     }
 
     /**

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/WorkerIdentification.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/WorkerIdentification.java
@@ -7,12 +7,15 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
+ * This interface provides encapsulates functionality to identify a worker and retrieve the worker's data record.
+ *
  * Created by marcel on 19.01.16.
  */
 @FunctionalInterface
 public interface WorkerIdentification {
     /**
-     * Parse a worker id out of the params
+     * Parse a worker id out of the params.
+     * This may only work once for the given params and is platform dependant.
      * @param param The parameters which were sent by a platform
      * @return The id of the worker if one can be found
      */
@@ -23,12 +26,11 @@ public interface WorkerIdentification {
      *
      * @param workerOperations The worker operations to use
      * @param platform The platform on which this is called
-     * @param param The parameters of the platform
+     * @param identification The previously obtained identification of the worker
      * @return A WorkerRecord, if one is found
      * @throws UnidentifiedWorkerException
      */
-    default Optional<WorkerRecord> getWorker(WorkerOperations workerOperations, String platform, Map<String, String[]> param) throws UnidentifiedWorkerException {
-        String uid = identifyWorker(param);
-        return workerOperations.getWorker(platform, uid);
+    default Optional<WorkerRecord> getWorker(String identification, WorkerOperations workerOperations, String platform) throws UnidentifiedWorkerException {
+        return workerOperations.getWorker(platform, identification);
     }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/rest/resources/WorkerResource.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/rest/resources/WorkerResource.java
@@ -43,12 +43,12 @@ public class WorkerResource {
         try {
             WorkerRecord worker;
             String platform = request.params("platform");
-            Optional<WorkerRecord> optionalRecord = manager.getWorker(platform, request.queryMap().toMap());
+            String identification = manager.identifyWorker(platform, request.queryMap().toMap());
+            Optional<WorkerRecord> optionalRecord = manager.getWorker(platform, identification);
             if (optionalRecord.isPresent()) {
                 worker = optionalRecord.get();
             } else if (!manager.getNeedemail(platform) || (request.queryParams("email") != null && !request.queryParams("email").isEmpty())){
-                String identify = manager.identifyWorker(platform, request.queryMap().toMap());
-                WorkerRecord workerRecord = new WorkerRecord(null, identify, platform, null, null);
+                WorkerRecord workerRecord = new WorkerRecord(null, identification, platform, null, null);
                 worker = operations.insertWorker(workerRecord);
             } else {
                 throw new NotFoundException();


### PR DESCRIPTION
Fix workerIdentfication to not call identifyWorker() more than once per request, as there are platforms that might not be able to identify a worker for given parameters more than once.
