### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM java:8
+
+COPY src /src
+COPY build.gradle /build.gradle
+COPY settings.gradle /settings.gradle
+COPY gradlew /gradlew
+COPY gradle /gradle
+
+RUN /gradlew prepareDocker
+
+COPY image/conf /conf
+COPY image/run.sh run.sh
+
+#web
+EXPOSE 4567
+
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ COPY gradlew /gradlew
 COPY gradle /gradle
 
 RUN /gradlew prepareDocker
+RUN /gradlew clean
 RUN rm -rf .gradle/
-RUN rm -rf build/
-RUN rm -rf /root/.gradle/
+RUN rm -rf $HOME/.gradle/caches/
 
 COPY image/conf /conf
 COPY image/run.sh run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ COPY gradlew /gradlew
 COPY gradle /gradle
 
 RUN /gradlew prepareDocker
+RUN rm -rf .gradle/
+RUN rm -rf build/
+RUN rm -rf /root/.gradle/
 
 COPY image/conf /conf
 COPY image/run.sh run.sh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Docker:
 
-To start the backend, you can download the [docker-compose file](https://github.com/coolcrowd/object-service/blob/master/image/compose/docker-compose.yml) and 
+To start the backend, you can download the [docker-compose file](https://raw.githubusercontent.com/coolcrowd/object-service/docker/image/compose/docker-compose.yml) and 
 run `docker-compose up` (assuming docker is installed) to start the backend.
 
 ### Jar:
@@ -20,7 +20,7 @@ How to build the object-service is detailed below.
 ## Configuration
 
 It is possible to pass `-Dobjectservice.config=configLocation` to specify the config-location, the configuration file is detailed 
-[here](https://github.com/coolcrowd/object-service/blob/master/src/main/resources/config.sample.yml).
+[here](https://raw.githubusercontent.com/coolcrowd/object-service/master/src/main/resources/config.sample.yml).
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 ### Docker:
 
 To start the backend, you can download the [docker-compose file](https://raw.githubusercontent.com/coolcrowd/object-service/docker/image/compose/docker-compose.yml) and 
-run `docker-compose up` (assuming docker is installed) to start the backend.
+run `docker-compose up` (assuming docker is installed) to start the backend. It is only intended for development, not for production!
+Please create your own docker-compose file for production with suitable config-files.
 
 ### Jar:
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ git clone https://github.com/coolcrowd/object-service && cd object-service
 # Or create the jar
 ./gradlew fatJar
 ```
+
+## Run local installation with docker-compose
+
+Just delete the object-service entry and link the `- -Dos.url=http://objectservice:4567` to the running instance.
+The database is exposed at {dockerip}:3306`.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,33 @@
 [![Build Status](https://travis-ci.org/coolcrowd/object-service.svg?branch=master)](https://travis-ci.org/coolcrowd/object-service)
 [![Coverage Status](https://coveralls.io/repos/github/coolcrowd/object-service/badge.svg?branch=master)](https://coveralls.io/github/coolcrowd/object-service?branch=master)
 
-## Requirements
+# Running
+
+## Backend
+
+### Docker:
+
+To start the backend, you can download the [docker-compose file](https://github.com/coolcrowd/object-service/blob/master/image/compose/docker-compose.yml) and 
+run `docker-compose up` (assuming docker is installed) to start the backend.
+
+### Jar:
+
+How to build the object-service is detailed below.
+
+
+## Configuration
+
+It is possible to pass `-Dobjectservice.config=configLocation` to specify the config-location, the configuration file is detailed 
+[here](https://github.com/coolcrowd/object-service/blob/master/src/main/resources/config.sample.yml).
+
+
+## Installation
+
+### Requirements
 
  * Java 8
  * MySQL 5.6
  * Gradle (optional, but recommended)
-
-## Installation
 
 ```bash
 # Clone repository and change into its directory.
@@ -26,6 +46,7 @@ git clone https://github.com/coolcrowd/object-service && cd object-service
 
 # Run it.
 ./gradlew run
-```
 
-One can pass `-Dobjectservice.config=configLocation` to specify the config-location.
+# Or create the jar
+./gradlew fatJar
+```

--- a/build.gradle
+++ b/build.gradle
@@ -222,3 +222,12 @@ task fatJar(type: Jar) {
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
+
+//docker-related
+task prepareDocker(type: Copy) {
+    dependsOn "fatJar"
+    file("./bin").mkdirs()
+    from "$buildDir/libs/" + project.name + '-all-' + project.version +".jar"
+    into "./bin"
+    rename (project.name + '-all-' + project.version +".jar", project.name + '.jar')
+}

--- a/image/buildImage.sh
+++ b/image/buildImage.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker build -t coolcrowd/objectservice:0.5 ..

--- a/image/compose/docker-compose.yml
+++ b/image/compose/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  objectservice:
+    image: coolcrowd/object-service:latest
+    ports:
+     - "4567:4567"
+    depends_on:
+     - db
+    links:
+     - db
+  db:
+    image: mysql:latest
+    environment:
+      MYSQL_DATABASE: crowdcontrol
+      MYSQL_USER: user
+      MYSQL_PASSWORD: 123456
+      MYSQL_ROOT_PASSWORD: root

--- a/image/compose/docker-compose.yml
+++ b/image/compose/docker-compose.yml
@@ -8,6 +8,21 @@ services:
      - db
     links:
      - db:db
+  workerservice:
+    image: coolcrowd/worker-service:latest
+    ports:
+      - "3333:4567"
+    depends_on:
+         - db
+         - objectservice
+    links:
+         - db:db
+         - objectservice:objectservice
+    command:
+            - -Ddatabase.url=jdbc:mysql://db
+            - -Ddatabase.username=root
+            - -Ddatabase.password=root
+            - -Dos.url=http://objectservice
   db:
     image: mysql:latest
     environment:

--- a/image/compose/docker-compose.yml
+++ b/image/compose/docker-compose.yml
@@ -22,7 +22,7 @@ services:
             - -Ddatabase.url=jdbc:mysql://db
             - -Ddatabase.username=root
             - -Ddatabase.password=root
-            - -Dos.url=http://objectservice
+            - -Dos.url=http://objectservice:4567
   db:
     image: mysql:latest
     environment:

--- a/image/compose/docker-compose.yml
+++ b/image/compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
      - db
     links:
-     - db
+     - db:db
   db:
     image: mysql:latest
     environment:
@@ -15,3 +15,7 @@ services:
       MYSQL_USER: user
       MYSQL_PASSWORD: 123456
       MYSQL_ROOT_PASSWORD: root
+    command:
+        - --character-set-server=utf8mb4
+    ports:
+         - "3306:3306"

--- a/image/conf/config.yml
+++ b/image/conf/config.yml
@@ -15,6 +15,11 @@ database:
         user: root
         password: root
 
+# basic configurations for the mail-module
+mail :
+    # disabled = true will ignore the mail configuration and print to the command-line
+    disabled : true
+
 # Deployment of the object service / control ui
 deployment:
     # Origin of the control ui

--- a/image/conf/config.yml
+++ b/image/conf/config.yml
@@ -24,7 +24,7 @@ mail :
 deployment:
     # Origin of the control ui
     # port has to match the url of the ui and no / at the end
-    origin: http://localhost:3000
+    origin: *
 
 # the defined platforms to run
 platforms :

--- a/image/conf/config.yml
+++ b/image/conf/config.yml
@@ -1,0 +1,30 @@
+database:
+    # the url where to find the database
+    url: jdbc:mysql://localhost:8888/crowdcontrol
+
+    # dialekt to use for communication
+    dialect: MYSQL
+
+    # the writing user
+    writing:
+        user: root
+        password: root
+
+    # readonly user should really just be readonly
+    readonly:
+        user: root
+        password: root
+
+# Deployment of the object service / control ui
+deployment:
+    # Origin of the control ui
+    # port has to match the url of the ui and no / at the end
+    origin: http://localhost:3000
+
+# the defined platforms to run
+platforms :
+    # type to use (mturk/pybossa/dummy)
+    - type: dummy
+
+      # name which is used to display
+      name: dummy

--- a/image/conf/config.yml
+++ b/image/conf/config.yml
@@ -1,6 +1,6 @@
 database:
     # the url where to find the database
-    url: jdbc:mysql://localhost:8888/crowdcontrol
+    url: jdbc:mysql://db:3306/crowdcontrol
 
     # dialekt to use for communication
     dialect: MYSQL
@@ -33,3 +33,9 @@ platforms :
 
       # name which is used to display
       name: dummy
+
+moneytransfer:
+    payOffThreshold: 0
+    parsingPassword: test
+    notificationMailAddress: pseipd@gmail.com
+    scheduleInterval: 7

--- a/image/run.sh
+++ b/image/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo The options are: $@
-java $@ -jar bin/ObjectService.jar
+java $@ -Dobjectservice.config=conf/config.yml -jar bin/ObjectService.jar

--- a/image/run.sh
+++ b/image/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo The options are: $@
+java $@ -jar bin/ObjectService.jar

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/Main.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/Main.java
@@ -72,6 +72,7 @@ public class Main {
 
         InputStream configStream;
         if (System.getProperty("objectservice.config") != null) {
+            LOGGER.debug("loading configuration from location: {}", System.getProperty("objectservice.config"));
             configStream = new FileInputStream(System.getProperty("objectservice.config"));
         } else {
             configStream = Main.class.getResourceAsStream("/config.yml");


### PR DESCRIPTION
added docker support.
In the future i want to run `docker-compose up` to start the entire backend to debug, but this is only possible after #145 is merged because the object-service and the worker-service are out of sync. Right now it starts an instance of mysql and the object-service. The docker compose file is not meant for production!

all the data is in the /images directory, but the docker file exists at project root because it makes the docker hub integration simpler.

the docker images are located [here](https://hub.docker.com/u/coolcrowd/dashboard/).
