### PR TITLE
Fix for Answer without valid ratings - RatingQualityByDistribution #191

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
@@ -463,4 +463,14 @@ public class AnswerRatingOperations extends AbstractOperations {
                         .or(DSL.condition(true))
         );
     }
+
+    /**
+     * Get all answers of the specified experiment for which at least one rating is present.
+     * @param expID id of the experiment
+     * @return all answers of the experiment with one or more ratings
+     */
+    public Result<AnswerRecord> getAnswersWithRatingsOfExperiment(int expID){
+        //TODO
+        return null;
+    }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
@@ -472,39 +472,18 @@ public class AnswerRatingOperations extends AbstractOperations {
                     .fetch();
     }
 
-    /**
-     * Get all answers of the specified experiment for which at least one rating is present.
-     * @param expID id of the experiment
-     * @return all answers of the experiment with one or more ratings
-     */
-    public List<AnswerRecord> getAnswersWithRatingsOfExperiment(int expID){
-        Field<Integer> count = DSL.count(RATING.ID_RATING).as("count");
-        return create.select(ANSWER.fields())
-                .select(count)
-                .from(ANSWER)
-                .join(RATING).onKey()
-                .where(ANSWER.EXPERIMENT.eq(expID))
-                .groupBy(ANSWER.fields())
-                .having(count.greaterThan(0))
-                .fetch(record -> record.into(ANSWER));
-    }
-
-    /**
-     * Gets all RatingRecords of the answer belonging to specified rating.
-     * @param rating belonging of the answer
-     * @return List of all ratingRecords of the answer specified via the given rating
-     */
-    public List<RatingRecord> getRatingsOfAnswerOfRating(Rating rating){
-        return null; //TODO
-    }
-
 
     /**
      * Gets the AnswerRecord belonging to the specified rating
      * @param rating of the answerRecord
      * @return AnswerRecord of specified rating
      */
-    public AnswerRecord getAnswerFromRating(Rating rating){
-        return null; //TODO
+    public Optional<AnswerRecord> getAnswerFromRating(Rating rating){
+        return create.selectFrom(ANSWER)
+                .where(ANSWER.ID_ANSWER.eq(
+                        DSL.select(RATING_RESERVATION.ANSWER)
+                            .where(RATING_RESERVATION.IDRESERVERD_RATING.eq(rating.getReservation()))
+                ))
+                .fetchOptional();
     }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
@@ -7,10 +7,7 @@ import edu.kit.ipd.crowdcontrol.objectservice.database.transformers.ExperimentTr
 import edu.kit.ipd.crowdcontrol.objectservice.proto.CalibrationAnswer;
 import edu.kit.ipd.crowdcontrol.objectservice.proto.Experiment;
 import edu.kit.ipd.crowdcontrol.objectservice.proto.Rating;
-import org.jooq.DSLContext;
-import org.jooq.Field;
-import org.jooq.Result;
-import org.jooq.SelectConditionStep;
+import org.jooq.*;
 import org.jooq.impl.DSL;
 
 import java.sql.Timestamp;
@@ -469,8 +466,15 @@ public class AnswerRatingOperations extends AbstractOperations {
      * @param expID id of the experiment
      * @return all answers of the experiment with one or more ratings
      */
-    public Result<AnswerRecord> getAnswersWithRatingsOfExperiment(int expID){
-        //TODO
-        return null;
+    public List<AnswerRecord> getAnswersWithRatingsOfExperiment(int expID){
+        Field<Integer> count = DSL.count(RATING.ID_RATING).as("count");
+        return create.select(ANSWER.fields())
+                .select(count)
+                .from(ANSWER)
+                .join(RATING).onKey()
+                .where(ANSWER.EXPERIMENT.eq(expID))
+                .groupBy(ANSWER.fields())
+                .having(count.greaterThan(0))
+                .fetch(record -> record.into(ANSWER));
     }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
@@ -477,4 +477,23 @@ public class AnswerRatingOperations extends AbstractOperations {
                 .having(count.greaterThan(0))
                 .fetch(record -> record.into(ANSWER));
     }
+
+    /**
+     * Gets all RatingRecords of the answer belonging to specified rating.
+     * @param rating belonging of the answer
+     * @return List of all ratingRecords of the answer specified via the given rating
+     */
+    public List<RatingRecord> getRatingsOfAnswerOfRating(Rating rating){
+        return null; //TODO
+    }
+
+
+    /**
+     * Gets the AnswerRecord belonging to the specified rating
+     * @param rating of the answerRecord
+     * @return AnswerRecord of specified rating
+     */
+    public AnswerRecord getAnswerFromRating(Rating rating){
+        return null; //TODO
+    }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/AnswerRatingOperations.java
@@ -462,6 +462,17 @@ public class AnswerRatingOperations extends AbstractOperations {
     }
 
     /**
+     * returns all the ratings pointing to the same answer
+     * @param answersID the answer-ID
+     * @return a list of ratings
+     */
+    public List<RatingRecord> getRelatedRatings(int answersID) {
+        return create.selectFrom(RATING)
+                    .where(RATING.ANSWER_R.eq(answersID))
+                    .fetch();
+    }
+
+    /**
      * Get all answers of the specified experiment for which at least one rating is present.
      * @param expID id of the experiment
      * @return all answers of the experiment with one or more ratings

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
@@ -169,7 +169,9 @@ public class QualityIdentificator {
      * @param params Mapping of parameter-records to the user specified parameters represented as a string
      */
     private void rateQualityOfRatings(Rating rating, Map<AlgorithmRatingQualityParamRecord, String> params) {
-            List<RatingRecord> records = answerRatingOperations.getRatingsOfAnswerOfRating(rating);
+            AnswerRecord answerRecord = answerRatingOperations.getAnswerFromRating(rating)
+                    .orElseThrow(()->new IllegalArgumentException("Error, cant find find answer of given rating of expID: "+rating.getExperimentId()));
+            List<RatingRecord> records = answerRatingOperations.getRelatedRatings(answerRecord.getIdAnswer());
             Map<RatingRecord, Integer> map = ratingIdentifier.identifyRatingQuality(records, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
             answerRatingOperations.setQualityToRatings(map);
     }
@@ -187,7 +189,9 @@ public class QualityIdentificator {
      */
     private void rateQualityOfAnswers(Rating rating, Map<AlgorithmAnswerQualityParamRecord, String> params) {
 
-        AnswerRecord answerRecord = answerRatingOperations.getAnswerFromRating(rating);
+        AnswerRecord answerRecord = answerRatingOperations.getAnswerFromRating(rating)
+                .orElseThrow(()->new IllegalArgumentException("Error, cant find find answer of given rating of expID: "+rating.getExperimentId()));
+
         Map<String, Integer> result;
         result = answerIdentifier.identifyAnswerQuality(answerRatingOperations, answerRecord, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
         answerRatingOperations.setQualityToAnswer(answerRecord, result.get(AnswerQualityStrategy.QUALITY));

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
@@ -189,14 +189,14 @@ public class QualityIdentificator {
 
         AnswerRecord answerRecord = answerRatingOperations.getAnswerFromRating(rating);
         Map<String, Integer> result;
-            result = answerIdentifier.identifyAnswerQuality(answerRatingOperations, answerRecord, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
-            answerRatingOperations.setQualityToAnswer(answerRecord, result.get(AnswerQualityStrategy.QUALITY));
+        result = answerIdentifier.identifyAnswerQuality(answerRatingOperations, answerRecord, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
+        answerRatingOperations.setQualityToAnswer(answerRecord, result.get(AnswerQualityStrategy.QUALITY));
 
-            // Checks if quality_assured bit can be set.
-            if ((((double) result.get(AnswerQualityStrategy.NUM_OF_RATINGS) / (double) experimentOperations.getExperiment(answerRecord.getExperiment())
-                    .orElseThrow(() -> new IllegalArgumentException("Error, can't find experiment of given experiment-ID: "+answerRecord.getExperiment())).getRatingsPerAnswer()) >= 0.8)) {
-                answerRatingOperations.setAnswerQualityAssured(answerRecord);
-            }
+        // Checks if quality_assured bit can be set.
+        if ((((double) result.get(AnswerQualityStrategy.NUM_OF_RATINGS) / (double) experimentOperations.getExperiment(answerRecord.getExperiment())
+                .orElseThrow(() -> new IllegalArgumentException("Error, can't find experiment of given experiment-ID: "+answerRecord.getExperiment())).getRatingsPerAnswer()) >= 0.8)) {
+            answerRatingOperations.setAnswerQualityAssured(answerRecord);
+        }
 
     }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
@@ -7,6 +7,7 @@ import edu.kit.ipd.crowdcontrol.objectservice.database.operations.ExperimentOper
 import edu.kit.ipd.crowdcontrol.objectservice.database.transformers.ExperimentTransformer;
 import edu.kit.ipd.crowdcontrol.objectservice.event.Event;
 import edu.kit.ipd.crowdcontrol.objectservice.event.EventManager;
+import edu.kit.ipd.crowdcontrol.objectservice.proto.Experiment;
 import edu.kit.ipd.crowdcontrol.objectservice.proto.Rating;
 import edu.kit.ipd.crowdcontrol.objectservice.quality.answerQuality.AnswerQualityByRatings;
 import edu.kit.ipd.crowdcontrol.objectservice.quality.answerQuality.AnswerQualityStrategy;
@@ -154,7 +155,7 @@ public class QualityIdentificator {
      * @param experiment to be checked
      */
     private void checkExpStatus(ExperimentRecord experiment) {
-        if (experiment.getNeededAnswers() == answerOperations.getNumberOfFinalGoodAnswers(experiment.getIdExperiment())) {
+        if (experiment.getNeededAnswers() <= answerOperations.getNumberOfFinalGoodAnswers(experiment.getIdExperiment())) {
             experimentResource.endExperiment(ExperimentTransformer.toProto(experiment, experimentOperations.getExperimentState(experiment.getIdExperiment())));
         }
 
@@ -169,7 +170,7 @@ public class QualityIdentificator {
      */
     private void rateQualityOfRatings(ExperimentRecord experimentRecord, Map<AlgorithmRatingQualityParamRecord, String> params) {
 
-        List<AnswerRecord> answers = answerOperations.getAnswersOfExperiment(experimentRecord.getIdExperiment());
+        List<AnswerRecord> answers = answerOperations.getAnswersWithRatingsOfExperiment(experimentRecord.getIdExperiment());
 
         for (AnswerRecord answer : answers) {
             List<RatingRecord> records = answerOperations.getRatingsOfAnswer(answer);
@@ -191,7 +192,7 @@ public class QualityIdentificator {
      */
     private void rateQualityOfAnswers(ExperimentRecord experimentRecord, Map<AlgorithmAnswerQualityParamRecord, String> params) {
 
-        List<AnswerRecord> answers = answerOperations.getAnswersOfExperiment(experimentRecord.getIdExperiment());
+        List<AnswerRecord> answers = answerOperations.getAnswersWithRatingsOfExperiment(experimentRecord.getIdExperiment());
         Map<String, Integer> result;
         for (AnswerRecord answer : answers) {
             result = answerIdentifier.identifyAnswerQuality(answerOperations, answer, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/quality/QualityIdentificator.java
@@ -7,7 +7,6 @@ import edu.kit.ipd.crowdcontrol.objectservice.database.operations.ExperimentOper
 import edu.kit.ipd.crowdcontrol.objectservice.database.transformers.ExperimentTransformer;
 import edu.kit.ipd.crowdcontrol.objectservice.event.Event;
 import edu.kit.ipd.crowdcontrol.objectservice.event.EventManager;
-import edu.kit.ipd.crowdcontrol.objectservice.proto.Experiment;
 import edu.kit.ipd.crowdcontrol.objectservice.proto.Rating;
 import edu.kit.ipd.crowdcontrol.objectservice.quality.answerQuality.AnswerQualityByRatings;
 import edu.kit.ipd.crowdcontrol.objectservice.quality.answerQuality.AnswerQualityStrategy;
@@ -39,7 +38,7 @@ public class QualityIdentificator {
     private final Logger log = LogManager.getLogger(QualityIdentificator.class);
     private final Observable<Event<Rating>> ratingObservable = EventManager.RATINGS_CREATE.getObservable();
     private final ExperimentResource experimentResource;
-    private final AnswerRatingOperations answerOperations;
+    private final AnswerRatingOperations answerRatingOperations;
     private final ExperimentOperations experimentOperations;
     private final AlgorithmOperations algorithmOperations;
     private final Set<AnswerQualityStrategy> answerAlgorithms;
@@ -58,7 +57,7 @@ public class QualityIdentificator {
     public QualityIdentificator(AlgorithmOperations algorithmOperations, AnswerRatingOperations answerRatingOperations, ExperimentOperations experimentOperations, ExperimentResource experimentResource) {
 
         this.experimentResource = experimentResource;
-        this.answerOperations = answerRatingOperations;
+        this.answerRatingOperations = answerRatingOperations;
         this.experimentOperations = experimentOperations;
         this.algorithmOperations = algorithmOperations;
         this.answerAlgorithms = new HashSet<>();
@@ -106,8 +105,8 @@ public class QualityIdentificator {
             return new AnswerQualityByRatings();
         });
 
-        rateQualityOfRatings(exp, algorithmOperations.getRatingQualityParams(ratingIdentifier.getAlgorithmName(), exp.getIdExperiment()));
-        rateQualityOfAnswers(exp, algorithmOperations.getAnswerQualityParams(answerIdentifier.getAlgorithmName(), exp.getIdExperiment()));
+        rateQualityOfRatings(rating, algorithmOperations.getRatingQualityParams(ratingIdentifier.getAlgorithmName(), exp.getIdExperiment()));
+        rateQualityOfAnswers(rating, algorithmOperations.getAnswerQualityParams(answerIdentifier.getAlgorithmName(), exp.getIdExperiment()));
 
         checkExpStatus(exp);
 
@@ -155,7 +154,7 @@ public class QualityIdentificator {
      * @param experiment to be checked
      */
     private void checkExpStatus(ExperimentRecord experiment) {
-        if (experiment.getNeededAnswers() <= answerOperations.getNumberOfFinalGoodAnswers(experiment.getIdExperiment())) {
+        if (experiment.getNeededAnswers() <= answerRatingOperations.getNumberOfFinalGoodAnswers(experiment.getIdExperiment())) {
             experimentResource.endExperiment(ExperimentTransformer.toProto(experiment, experimentOperations.getExperimentState(experiment.getIdExperiment())));
         }
 
@@ -166,43 +165,39 @@ public class QualityIdentificator {
      * Rates and sets quality of all ratings of specified experiment.
      * Ratings to the same answer are grouped and rated together.
      *
-     * @param experimentRecord whose ratings' qualities are going to be estimated
+     * @param rating whose ratings' qualities are going to be estimated
+     * @param params Mapping of parameter-records to the user specified parameters represented as a string
      */
-    private void rateQualityOfRatings(ExperimentRecord experimentRecord, Map<AlgorithmRatingQualityParamRecord, String> params) {
-
-        List<AnswerRecord> answers = answerOperations.getAnswersWithRatingsOfExperiment(experimentRecord.getIdExperiment());
-
-        for (AnswerRecord answer : answers) {
-            List<RatingRecord> records = answerOperations.getRatingsOfAnswer(answer);
+    private void rateQualityOfRatings(Rating rating, Map<AlgorithmRatingQualityParamRecord, String> params) {
+            List<RatingRecord> records = answerRatingOperations.getRatingsOfAnswerOfRating(rating);
             Map<RatingRecord, Integer> map = ratingIdentifier.identifyRatingQuality(records, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
-            answerOperations.setQualityToRatings(map);
-        }
-
+            answerRatingOperations.setQualityToRatings(map);
     }
 
 
     /**
      * Rates and sets quality of all answers of specified experiment.
-     * Only uses ratings of a specified quality (@ratingQualityThreshold)
+     * Only uses ratings of a specified quality
      * Furthermore checks if a specified amount of ratings is present for that answer
      * and it thus the answer's quality is unlikely to change. In that case the corresponding
      * quality-assured-bit is set in the database.
      *
-     * @param experimentRecord the experiment whose answers are going to be rated
+     * @param rating the rating wof the answer which is going to be rated
+     * @param params Mapping of parameter-records to the user specified parameters represented as a string
      */
-    private void rateQualityOfAnswers(ExperimentRecord experimentRecord, Map<AlgorithmAnswerQualityParamRecord, String> params) {
+    private void rateQualityOfAnswers(Rating rating, Map<AlgorithmAnswerQualityParamRecord, String> params) {
 
-        List<AnswerRecord> answers = answerOperations.getAnswersWithRatingsOfExperiment(experimentRecord.getIdExperiment());
+        AnswerRecord answerRecord = answerRatingOperations.getAnswerFromRating(rating);
         Map<String, Integer> result;
-        for (AnswerRecord answer : answers) {
-            result = answerIdentifier.identifyAnswerQuality(answerOperations, answer, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
-            answerOperations.setQualityToAnswer(answer, result.get(AnswerQualityStrategy.QUALITY));
+            result = answerIdentifier.identifyAnswerQuality(answerRatingOperations, answerRecord, params, MAXIMUM_QUALITY, MINIMUM_QUALITY);
+            answerRatingOperations.setQualityToAnswer(answerRecord, result.get(AnswerQualityStrategy.QUALITY));
 
             // Checks if quality_assured bit can be set.
-            if ((((double) result.get(AnswerQualityStrategy.NUM_OF_RATINGS) / (double) experimentRecord.getRatingsPerAnswer()) >= 0.8)) {
-                answerOperations.setAnswerQualityAssured(answer);
+            if ((((double) result.get(AnswerQualityStrategy.NUM_OF_RATINGS) / (double) experimentOperations.getExperiment(answerRecord.getExperiment())
+                    .orElseThrow(() -> new IllegalArgumentException("Error, can't find experiment of given experiment-ID: "+answerRecord.getExperiment())).getRatingsPerAnswer()) >= 0.8)) {
+                answerRatingOperations.setAnswerQualityAssured(answerRecord);
             }
-        }
+
     }
 }
 


### PR DESCRIPTION
- Now request only answers with present ratings for quality-identificaion. This solves the ratingSubmission error and avoids unnecessary db-ops on answers w/o ratings.
- Additionally removes unnecessary checks of answers and ratings not being affected by a submitted rating
