### PR TITLE
more tests and added close to interface

### DIFF
--- a/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailHandlerTest.java
+++ b/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailHandlerTest.java
@@ -5,9 +5,11 @@ import edu.kit.ipd.crowdcontrol.objectservice.config.Config;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.mail.FolderClosedException;
 import javax.mail.Message;
 import java.util.UUID;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -53,7 +55,7 @@ public class MailHandlerTest {
     }
 
     @Test
-    public void test() throws Exception {
+    public void testSendAndFetch() throws Exception {
         String uuid = UUID.randomUUID().toString();
         String subject = "[test] " + uuid;
 
@@ -75,5 +77,79 @@ public class MailHandlerTest {
             }
         }
         assertTrue(found);
+
+        messages = fetcher.fetchFolder(folder);
+        found = false;
+        for (Message message : messages) {
+            if (message.getSubject().equals(subject)) {
+                found = true;
+                break;
+            }
+        }
+        assertFalse(found);
+    }
+
+    @Test
+    public void testFetchUnseenMarkAsUnseen() throws Exception {
+        String uuid = UUID.randomUUID().toString();
+        String subject = "[test] " + uuid;
+
+        sender.sendMail(receiver, subject, uuid);
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+        }
+        Message[] messages = fetcher.fetchUnseen(folder);
+
+        boolean found = false;
+
+        Message testMessage = null;
+        for (Message message : messages) {
+            if (message.getSubject().equals(subject)) {
+                found = true;
+                testMessage = message;
+                break;
+            }
+        }
+        assertTrue(found);
+
+        messages = fetcher.fetchUnseen(folder);
+
+        found = false;
+        for (Message message : messages) {
+            if (message.getSubject().equals(subject)) {
+                found = true;
+                break;
+            }
+        }
+        assertFalse(found);
+
+        fetcher.markAsUnseen(testMessage);
+        messages = fetcher.fetchUnseen(folder);
+        found = false;
+        for (Message message : messages) {
+            if (message.getSubject().equals(subject)) {
+                found = true;
+                fetcher.deleteMails(message);
+                break;
+            }
+        }
+        assertTrue(found);
+    }
+
+    @Test(expected = FolderClosedException.class)
+    public void testOpenAndClose() throws Exception {
+        String uuid = UUID.randomUUID().toString();
+        String subject = "[test] " + uuid;
+
+        sender.sendMail(receiver, subject, uuid);
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+        }
+
+        Message[] messages = fetcher.fetchFolder(folder);
+        fetcher.close(messages);
+        messages[0].getSubject();
     }
 }

--- a/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailHandlerTest.java
+++ b/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailHandlerTest.java
@@ -149,7 +149,7 @@ public class MailHandlerTest {
         }
 
         Message[] messages = fetcher.fetchFolder(folder);
-        fetcher.close(messages);
+        fetcher.close(messages[0].getFolder());
         messages[0].getSubject();
     }
 }

--- a/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailHandlerTest.java
+++ b/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailHandlerTest.java
@@ -108,6 +108,7 @@ public class MailHandlerTest {
             if (message.getSubject().equals(subject)) {
                 found = true;
                 testMessage = message;
+                fetcher.markAsSeen(message);
                 break;
             }
         }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/CommandLineMailHandler.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/CommandLineMailHandler.java
@@ -16,11 +16,9 @@ import java.io.UnsupportedEncodingException;
 public class CommandLineMailHandler implements MailSender, MailFetcher {
     private static final Logger LOGGER = LogManager.getLogger(CommandLineMailHandler.class);
 
+
     /**
-     * Fetches all unseen mails in a certain folder and marks them as seen.
-     *
-     * @param name the name of the folder
-     * @return fetched mails
+     * {@inheritDoc}
      */
     @Override
     public Message[] fetchUnseen(String name) throws MessagingException {
@@ -28,11 +26,9 @@ public class CommandLineMailHandler implements MailSender, MailFetcher {
         return new Message[0];
     }
 
+
     /**
-     * Fetches all mails in a folder and marks them as seen.
-     *
-     * @param name the name of the folder
-     * @return fetched mails
+     * {@inheritDoc}
      */
     @Override
     public Message[] fetchFolder(String name) throws MessagingException {
@@ -40,43 +36,48 @@ public class CommandLineMailHandler implements MailSender, MailFetcher {
         return new Message[0];
     }
 
+
     /**
-     * Marks a message in a certain folder as unseen.
-     *
-     * @param message the message to mark
-     * @throws MessagingException throws a MessagingException, if there are any problems with the message
+     * {@inheritDoc}
      */
     @Override
     public void markAsUnseen(Message message) throws MessagingException {
         LOGGER.debug("call to markAsUnseen with message: {}", message);
     }
 
+
     /**
-     * Deletes a message from the folder.
-     *
-     * @param message the message to delete
-     * @throws MessagingException throws a MessagingException, if there are any problems with the message
+     * {@inheritDoc}
      */
     @Override
     public void deleteMails(Message message) throws MessagingException {
         LOGGER.debug("call to deleteMails with message: {}", message);
     }
 
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Message[] fetchUnseen() throws MessagingException {
         return new Message[0];
     }
 
+
     /**
-     * Sends mails to another mail address.
-     *
-     * @param recipientMail the mail address, the mail gets sent
-     * @param subject       the subject of the mail
-     * @param message       the content of the mail
+     * {@inheritDoc}
      */
     @Override
     public void sendMail(String recipientMail, String subject, String message) throws MessagingException, UnsupportedEncodingException {
         LOGGER.info("call to sendMail, parameters recipientMail : {}, subject : {}, message: {}",
                 recipientMail, subject, message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close(Message[] messages) {
+        LOGGER.info("call to close with messages{}", messages);
     }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/CommandLineMailHandler.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/CommandLineMailHandler.java
@@ -3,6 +3,7 @@ package edu.kit.ipd.crowdcontrol.objectservice.mail;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.mail.Folder;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 
@@ -77,7 +78,7 @@ public class CommandLineMailHandler implements MailSender, MailFetcher {
      * {@inheritDoc}
      */
     @Override
-    public void close(Message[] messages) {
-        LOGGER.info("call to close with messages{}", messages);
+    public void close(Folder folder) {
+        LOGGER.info("call to close with folder: {}", folder);
     }
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/CommandLineMailHandler.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/CommandLineMailHandler.java
@@ -23,7 +23,7 @@ public class CommandLineMailHandler implements MailSender, MailFetcher {
      */
     @Override
     public Message[] fetchUnseen(String name) throws MessagingException {
-        LOGGER.debug("call to fetchUnseen");
+        LOGGER.debug("call to fetchUnseen with folder: {}", name);
         return new Message[0];
     }
 
@@ -33,7 +33,7 @@ public class CommandLineMailHandler implements MailSender, MailFetcher {
      */
     @Override
     public Message[] fetchFolder(String name) throws MessagingException {
-        LOGGER.debug("call to fetchUnseen");
+        LOGGER.debug("call to fetchFolder with folder: {}", name);
         return new Message[0];
     }
 
@@ -44,6 +44,14 @@ public class CommandLineMailHandler implements MailSender, MailFetcher {
     @Override
     public void markAsUnseen(Message message) throws MessagingException {
         LOGGER.debug("call to markAsUnseen with message: {}", message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void markAsSeen(Message message) throws MessagingException {
+        LOGGER.debug("call to markAsSeen with message: {}", message);
     }
 
 

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
@@ -45,4 +45,11 @@ public interface MailFetcher {
      * @return A array of unseen mails
      */
     Message[] fetchUnseen() throws MessagingException;
+
+    /**
+     * Closes the folder and the store of the messages.
+     * @param messages the messages their resources become closed (have to be in the same folder)
+     * @throws MessagingException in case of problems with closing
+     */
+    void close(Message[] messages) throws MessagingException;
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
@@ -42,7 +42,7 @@ public interface MailFetcher {
     void deleteMails(Message message) throws MessagingException;
 
     /**
-     * Get all unseen mail from the default location
+     * Get all unseen mail from the default location and marks them as seen.
      * @return A array of unseen mails
      */
     Message[] fetchUnseen() throws MessagingException;

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
@@ -12,7 +12,7 @@ import javax.mail.MessagingException;
  */
 public interface MailFetcher {
     /**
-     * Fetches all unseen mails in a certain folder and marks them as seen.
+     * Fetches all unseen mails in a certain folder.
      *
      * @param name the name of the folder
      * @return fetched mails
@@ -20,7 +20,7 @@ public interface MailFetcher {
     Message[] fetchUnseen(String name) throws MessagingException;
 
     /**
-     * Fetches all mails in a folder and marks them as seen.
+     * Fetches all mails in a folder.
      *
      * @param name the name of the folder
      * @return fetched mails
@@ -35,6 +35,13 @@ public interface MailFetcher {
     void markAsUnseen(Message message) throws MessagingException;
 
     /**
+     * Marks a message in a certain folder as seen.
+     * @param message the message to mark
+     * @throws MessagingException throws a MessagingException, if there are any problems with the message
+     */
+    void markAsSeen(Message message) throws MessagingException;
+
+    /**
      * Deletes a message from the folder.
      * @param message the message to delete
      * @throws MessagingException throws a MessagingException, if there are any problems with the message
@@ -42,7 +49,7 @@ public interface MailFetcher {
     void deleteMails(Message message) throws MessagingException;
 
     /**
-     * Get all unseen mail from the default location and marks them as seen.
+     * Get all unseen mail from the default location.
      * @return A array of unseen mails
      */
     Message[] fetchUnseen() throws MessagingException;

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailFetcher.java
@@ -1,5 +1,6 @@
 package edu.kit.ipd.crowdcontrol.objectservice.mail;
 
+import javax.mail.Folder;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 
@@ -47,9 +48,9 @@ public interface MailFetcher {
     Message[] fetchUnseen() throws MessagingException;
 
     /**
-     * Closes the folder and the store of the messages.
-     * @param messages the messages their resources become closed (have to be in the same folder)
+     * Closes a folder and its resources.
+     * @param folder the folder to close
      * @throws MessagingException in case of problems with closing
      */
-    void close(Message[] messages) throws MessagingException;
+    void close(Folder folder) throws MessagingException;
 }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailReceiver.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailReceiver.java
@@ -175,12 +175,12 @@ public class MailReceiver implements MailFetcher {
     @Override
     public void close(Folder folder) throws MessagingException {
         LOGGER.trace("Started closing folder " + folder.getFullName() + ".");
-            if (folder.isOpen()) {
-                folder.close(true);
-            }
-            if (folder.getStore().isConnected()) {
-                folder.getStore().close();
-            }
+        if (folder.isOpen()) {
+            folder.close(true);
+        }
+        if (folder.getStore().isConnected()) {
+            folder.getStore().close();
+        }
 
         LOGGER.trace("Successfully completed closing folder " + folder.getFullName() + ".");
     }

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailReceiver.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailReceiver.java
@@ -161,16 +161,18 @@ public class MailReceiver implements MailFetcher {
         LOGGER.trace("Successfully completed deleting message with subject \"" + message.getSubject() + "\".");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Message[] fetchUnseen() throws MessagingException {
         return fetchUnseen(defaultInbox);
     }
 
     /**
-     * Closes the folder and the store of the messages.
-     * @param messages the messages their resources become closed (have to be in the same folder)
-     * @throws MessagingException in case of problems with closing
+     * {@inheritDoc}
      */
+    @Override
     public void close(Message[] messages) throws MessagingException {
         LOGGER.trace("Started closing folder of " + messages.length + " messages.");
         if (messages.length > 0) {

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailReceiver.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/mail/MailReceiver.java
@@ -173,17 +173,16 @@ public class MailReceiver implements MailFetcher {
      * {@inheritDoc}
      */
     @Override
-    public void close(Message[] messages) throws MessagingException {
-        LOGGER.trace("Started closing folder of " + messages.length + " messages.");
-        if (messages.length > 0) {
-            if (messages[0].getFolder().isOpen()) {
-                messages[0].getFolder().close(true);
+    public void close(Folder folder) throws MessagingException {
+        LOGGER.trace("Started closing folder " + folder.getFullName() + ".");
+            if (folder.isOpen()) {
+                folder.close(true);
             }
-            if (messages[0].getFolder().getStore().isConnected()) {
-                messages[0].getFolder().getStore().close();
+            if (folder.getStore().isConnected()) {
+                folder.getStore().close();
             }
-        }
-        LOGGER.trace("Successfully completed closing folder of " + messages.length + " messages.");
+
+        LOGGER.trace("Successfully completed closing folder " + folder.getFullName() + ".");
     }
 
     private Store connect() throws MessagingException {


### PR DESCRIPTION
until now, the close method was just a method of the mailReceiver, but not of the mailFetcher interface. If you declare a MailSender as MailFetcher (how it is in CrowdControl), the close()-method wasn't available.
