### PR TITLE
Throw IllegalArgumentException instead of NPE

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/template/Template.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/template/Template.java
@@ -72,6 +72,16 @@ public class Template {
      * @return Rendered template.
      */
     public static String apply(String text, Map<String, String> placeholders) {
+        if (text == null) {
+            throw new IllegalArgumentException("Text must not be null!");
+        }
+
+        for (String key : placeholders.keySet()) {
+            if (placeholders.get(key) == null) {
+                throw new IllegalArgumentException("Placeholder '" + key + "' must not be null!");
+            }
+        }
+
         Map<String, Placeholder> placeholderMap = parse(text);
 
         if (!placeholderMap.keySet().equals(placeholders.keySet())) {

--- a/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/template/TemplateTest.java
+++ b/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/template/TemplateTest.java
@@ -43,6 +43,19 @@ public class TemplateTest {
 	}
 
 	@Test (expected = IllegalArgumentException.class)
+	public void applyNullText() {
+		Template.apply(null, new HashMap<>());
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void applyNullPlaceholder() {
+		Map<String, String> map = new HashMap<>();
+		map.put("foo", null);
+
+		Template.apply("{{foo}}", map);
+	}
+
+	@Test (expected = IllegalArgumentException.class)
 	public void applyIllegal() {
 		Template.apply("{{Foobar}}", new HashMap<>());
 	}


### PR DESCRIPTION
When template placeholders are `null`.
