### PR TITLE
set state to shutdown

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/ExperimentOperator.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/ExperimentOperator.java
@@ -107,6 +107,8 @@ public class ExperimentOperator {
             statuses = experimentsPlatformOperations.getExperimentsPlatformStatusPlatformStatuses(experiment.getId());
             if (!statuses.stream().allMatch(state -> state == ExperimentsPlatformStatusPlatformStatus.shutdown)) {
                shutdownExperiment(experiment);
+            } else {
+                log.error("Ending experiment "+experiment.getId()+" failed");
             }
         }else if(!statuses.contains(ExperimentsPlatformStatusPlatformStatus.running)){
             log.info("Experiment "+experiment.getId()+" is not running ");

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/ExperimentOperator.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/ExperimentOperator.java
@@ -18,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.function.Predicate;
 
 /**
  * Presents starting and stopping experiment operations on populations
@@ -94,7 +95,6 @@ public class ExperimentOperator {
 
         Set<ExperimentsPlatformStatusPlatformStatus> statuses = experimentsPlatformOperations.getExperimentsPlatformStatusPlatformStatuses(experiment.getId());
          if(!statuses.contains(ExperimentsPlatformStatusPlatformStatus.shutdown)) {
-
             for (Experiment.Population population :
                     experiment.getPopulationsList()) {
                 try {
@@ -104,8 +104,10 @@ public class ExperimentOperator {
                 }
             }
 
-            experimentsPlatformOperations.setGlobalPlatformStatus(experiment, ExperimentsPlatformStatusPlatformStatus.shutdown);
-            shutdownExperiment(experiment);
+            statuses = experimentsPlatformOperations.getExperimentsPlatformStatusPlatformStatuses(experiment.getId());
+            if (!statuses.stream().allMatch(state -> state == ExperimentsPlatformStatusPlatformStatus.shutdown)) {
+               shutdownExperiment(experiment);
+            }
         }else if(!statuses.contains(ExperimentsPlatformStatusPlatformStatus.running)){
             log.info("Experiment "+experiment.getId()+" is not running ");
         }else {

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManager.java
@@ -196,7 +196,7 @@ public class PlatformManager {
 
                     if (success) {
                         experimentsPlatformOps.setPlatformStatus(record.getIdexperimentsPlatforms(),
-                                ExperimentsPlatformStatusPlatformStatus.finished);
+                                ExperimentsPlatformStatusPlatformStatus.shutdown);
                     }
                     return success;
                 });

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/model/enums/ExperimentsPlatformStatusPlatformStatus.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/model/enums/ExperimentsPlatformStatusPlatformStatus.java
@@ -35,6 +35,7 @@ public enum ExperimentsPlatformStatusPlatformStatus implements EnumType {
 
 	shutdown("shutdown"),
 
+	@Deprecated
 	stopped("stopped");
 
 	private final String literal;

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/ExperimentOperations.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/database/operations/ExperimentOperations.java
@@ -111,16 +111,19 @@ public class ExperimentOperations extends AbstractOperations {
         //TODO: what to do if one of the platforms failed?
         if (statuses.isEmpty()) {
             return Experiment.State.DRAFT;
+        } else if (statuses.size() != 1) {
+            //we have a inhomogeneous state, BAD!
+            return Experiment.State.INVALID;
         } else if (statuses.contains(ExperimentsPlatformStatusPlatformStatus.running)) {
             return Experiment.State.PUBLISHED;
         } else if (statuses.contains(ExperimentsPlatformStatusPlatformStatus.shutdown)) {
-            return Experiment.State.PUBLISHED; //TODO: maybe more options?
+            return Experiment.State.PUBLISHED;
         } else if (statuses.contains(ExperimentsPlatformStatusPlatformStatus.creative_stopping)) {
             return Experiment.State.CREATIVE_STOPPED;
-        } else if (statuses.contains(ExperimentsPlatformStatusPlatformStatus.stopped)) {
+        } else if (statuses.contains(ExperimentsPlatformStatusPlatformStatus.finished)) {
             return Experiment.State.STOPPED;
         } else {
-            return Experiment.State.STOPPED; //TODO: finished
+            return Experiment.State.INVALID;
         }
     }
 

--- a/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManagerTest.java
+++ b/src/test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/PlatformManagerTest.java
@@ -119,7 +119,7 @@ public class PlatformManagerTest {
             }
             //record.setStatus(TaskStatus.finished);
             verify(experimentsPlatformOperations).setPlatformStatus(record.getIdexperimentsPlatforms(),
-                    ExperimentsPlatformStatusPlatformStatus.finished);
+                    ExperimentsPlatformStatusPlatformStatus.shutdown);
         });
     }
 


### PR DESCRIPTION
This fixes handling of states
- platformManager sets the state of platforms to shutdown if the ending was successfully
- the experimentstate is now better mapped to states of a set of platforms
- deprecate stopped form the database and use finished.
