### PR TITLE
Mturk hitextender fix

### DIFF
--- a/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/MTurkRestApiTest.java
+++ b/src/integration-test/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/MTurkRestApiTest.java
@@ -57,7 +57,7 @@ public class MTurkRestApiTest {
                 0.20,60,2000,"test,for,everything",
                 2,2000000,"data","").get();
 
-        new ExtendHIT(connection, id, 2, 0).join();
+        new ExtendHIT(connection, id, 2, null).join();
 
         assertNotEquals(id, null);
 

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/HitExtender.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/HitExtender.java
@@ -86,9 +86,9 @@ public class HitExtender extends TimerTask {
         Function<HIT, CompletableFuture<Boolean>> hitExtend = (hit -> {
             LocalDate expire = hit.getExpiration().toGregorianCalendar().toZonedDateTime().toLocalDate();
             LocalDate minExpire = LocalDate.now().plusDays(MINIMUM_TIME_DAYS);
-            long minutes = ChronoUnit.DAYS.between(expire, minExpire);
-            if (minutes < 0) { //FIXME
-                LOGGER.trace("Update "+hit.getHITId()+" with up to "+minutes+" minutes");
+            long days = ChronoUnit.DAYS.between(expire, minExpire);
+            if (days > 0) {
+                LOGGER.trace("Update "+hit.getHITId()+" with up to "+days+" minutes");
                 return new ExtendHIT(connection, hit.getHITId(), 0, Duration.ofDays(2));
             }
             return CompletableFuture.completedFuture(true);

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/HitExtender.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/HitExtender.java
@@ -95,7 +95,8 @@ public class HitExtender extends TimerTask {
                     return true;
                 });
 
-        if (!workCopy.parallelStream().map(stringCompletableFutureFunction)
+        if (!workCopy.stream()
+                .map(stringCompletableFutureFunction)
                 .map(CompletableFuture::join)
                 .allMatch(Boolean::booleanValue)) {
             LOGGER.log(Level.ERROR, "Failed to extend hits");

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/HitExtender.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/HitExtender.java
@@ -8,7 +8,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -41,7 +44,7 @@ public class HitExtender extends TimerTask {
         this.hitIds.addAll(hitIds);
 
         Timer timer = new Timer();
-        timer.schedule(this, new Date(), TimeUnit.MILLISECONDS.convert(INTERVAL_RUN_HOURS, TimeUnit.HOURS));
+        timer.schedule(this, 0, TimeUnit.MILLISECONDS.convert(INTERVAL_RUN_HOURS, TimeUnit.HOURS));
     }
 
     /**

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/MturkRestCommand.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/MturkRestCommand.java
@@ -17,6 +17,8 @@ import javax.xml.transform.sax.SAXSource;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
 

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/command/ExtendHIT.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/command/ExtendHIT.java
@@ -4,15 +4,18 @@ import com.amazonaws.mturk.requester.doc._2014_08_15.ExtendHITResponse;
 import edu.kit.ipd.crowdcontrol.objectservice.crowdworking.mturk.MTurkConnection;
 import edu.kit.ipd.crowdcontrol.objectservice.crowdworking.mturk.MturkRestCommand;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by marcel on 17.03.16.
  */
 public class ExtendHIT extends MturkRestCommand<Boolean, ExtendHITResponse> {
 
-    public ExtendHIT(MTurkConnection con, String hitId, int increaseMaxAssignment, long increaseTimeOutSeconds) {
+    public ExtendHIT(MTurkConnection con, String hitId, int increaseMaxAssignment, Duration increaseTime) {
         super(con, "ExtendHIT", null, "2014-08-15", ExtendHITResponse.class,
                 () -> {
                     Map<String, Object> values = new HashMap<>();
@@ -21,8 +24,8 @@ public class ExtendHIT extends MturkRestCommand<Boolean, ExtendHITResponse> {
                     if (increaseMaxAssignment != 0)
                       values.put("MaxAssignmentsIncrement", increaseMaxAssignment+"");
 
-                    if (increaseTimeOutSeconds != 0)
-                      values.put("ExpirationIncrementInSeconds", increaseTimeOutSeconds+"");
+                    if (increaseTime != null)
+                      values.put("ExpirationIncrementInSeconds", increaseTime.getSeconds()+"");
 
                     return values;
                 },extendHITResponse -> {

--- a/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/command/GetHIT.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/objectservice/crowdworking/mturk/command/GetHIT.java
@@ -20,7 +20,7 @@ public class GetHIT extends MturkRestCommand<HIT, GetHITResponse> {
      */
     public GetHIT(MTurkConnection con, String id){
         super(con,
-                "GetHIT","HITDetail","2014-08-15", GetHITResponse.class,
+                "GetHIT", null, "2014-08-15", GetHITResponse.class,
                 () -> {
                     HashMap<String, Object> values = new HashMap<>();
                     values.put("HITId", id);


### PR DESCRIPTION
- Fixes not extending of HITs because of unsupported Seconds
- Makes ExtendHIT work by refactoring the code which creates the ExtendHIT call to mturk
