### PR TITLE
gradle: fix codegen version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile 'org.apache.logging.log4j:log4j-core:2.5'
     compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.0'
     compile 'org.yaml:snakeyaml:1.8'
-    compile 'org.jooq:jooq-codegen:3.+'
+    compile 'org.jooq:jooq-codegen:3.5.4'
     compile 'io.jsonwebtoken:jjwt:0.6.+'
     compile ('com.sparkjava:spark-core:2.3') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'


### PR DESCRIPTION
an unspecified jooq codegen version caused gradle to fetch the wrong dependency of the other jooq.* packages.